### PR TITLE
docs: discoverability pass

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot keeps dependencies current with small, regular PRs.
+# Minor and patch bumps are grouped into a single PR to keep the noise low;
+# majors are left as individual PRs so breaking changes get reviewed one at a time.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # Python dependencies declared in pyproject.toml (repo root).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Every minor + patch bump rides in one PR; majors stay individual.
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions pinned in the CI and publish workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      # One PR for every action bump (majors included).
+      github-actions:
+        patterns:
+          - "*"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# PrivAiTe — guide for AI agents (read this before changing code)
+# PrivAiTe, guide for AI agents (read this before changing code)
 
 PrivAiTe is a self-hosted, OpenAI-compatible proxy that **detects PII, replaces it
 with reversible placeholders before forwarding to the LLM provider, and restores
@@ -14,7 +14,7 @@ them as invariants, not suggestions.
    error. Startup refuses unsafe configs (see #6).
 2. **One choke point.** Every piece of user text reaches the provider only through
    `PIIEngine._anonymize_text`. The `block_entities` gate lives there. If you add a
-   new field/path that carries user text, route it through the engine — never
+   new field/path that carries user text, route it through the engine, never
    forward it directly.
 3. **Restore parity.** Whatever is anonymized must be restored on the way back, in
    **both streaming and non-streaming**: `content`, `tool_calls[].function.arguments`,
@@ -30,7 +30,7 @@ them as invariants, not suggestions.
    with 0 detectors, `merge_strategy: intersection` with <2 detectors, a Presidio
    language with no spaCy model, and duplicate provider `model_name` aliases all
    raise at boot.
-7. **Config defaults are the safety posture — do not flip them casually.**
+7. **Config defaults are the safety posture, do not flip them casually.**
    `preset: onnx` (~84.5% recall), `on_error: block`, `deanonymization.fuzzy_matching: false`
    (fuzzy can mis-substitute), detector `trust_remote_code: false`, `block_entities: []`.
 
@@ -54,7 +54,7 @@ endpoint module deliberately has no logger). Keep it excluded from /stats.
 ## Streaming handler (`privaite/streaming/handler.py`)
 
 Forward the provider's own chunks (preserve `id`, `usage`, `logprobs`, and the real
-finish chunk — do not synthesize a duplicate finish). One restore buffer **per
+finish chunk: do not synthesize a duplicate finish). One restore buffer **per
 choice index** (n>1 must not share). Flush held-back text onto the finish chunk and
 again after the stream ends without a `finish_reason`. Never suppress a chunk that
 carries any payload other than fully-held-back content.
@@ -64,7 +64,7 @@ carries any payload other than fully-held-back content.
 - Run in the repo venv (`.venv`): `pytest`, `ruff check`, `ruff format --check`,
   and **`mypy privaite/ integrations/openwebui/privaite_filter.py integrations/litellm/privaite_guardrail.py`**.
   The publish workflow type-checks the integrations even though the push CI does
-  not — skipping them once broke a release.
+  not: skipping them once broke a release.
 - Version: bump **both** `pyproject.toml` and `privaite/__init__.py`; date the
   `CHANGELOG.md` section; bump the integration pins (`privaite>=X`).
 - Benchmark: if you touched detection, re-run `privaite-bench`
@@ -73,7 +73,6 @@ carries any payload other than fully-held-back content.
 - Release: `gh release create vX.Y.Z` triggers `publish.yml` → PyPI (trusted
   publisher; its Environment field must stay empty). A PyPI version can never be
   reused, so verify green CI first.
-- Commit as the real git user, not claude
 
 ## Integrations must stay in sync with the core
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # PrivAiTe
 
+Self-hosted PII redaction proxy for LLM APIs.
+
 [![CI](https://github.com/crp4222/PrivAiTe/actions/workflows/ci.yml/badge.svg)](https://github.com/crp4222/PrivAiTe/actions)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-green.svg)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/privaite.svg)](https://pypi.org/project/privaite/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/privaite.svg)](https://pypi.org/project/privaite/)
 
-**A drop-in, self-hosted LLM proxy that reversibly redacts PII before it reaches the provider, including inside tool-call arguments and multimodal content, with zero telemetry.**
+**A drop-in LLM proxy that reversibly replaces PII before it reaches the provider, including inside tool-call arguments and multimodal content, with zero telemetry.**
 
 <p align="center">
   <img src="docs/demo.gif" alt="PrivAiTe demo: a tool call carrying an email, name and credit card has each value replaced with a placeholder before it reaches the LLM provider, with the JSON keys left intact, then de-anonymized in the reply" width="820">
 </p>
 
-Keep personal data out of your LLM calls. PrivAiTe is a local proxy that sits between your app and the model provider. It finds names, emails, phone numbers, cards, IBANs, secrets and more, swaps them for stand-ins before anything leaves your machine, and puts the real values back in the reply. It does this across message text, **tool-call arguments, and multimodal content**, which is where most tools stop looking. Detection runs on your machine and nothing phones home. By default it runs the full ONNX suite, so it also catches **secrets and passwords**, not just the easy regex entities. Point any OpenAI-compatible client at it.
+Keep personal data out of your LLM calls. PrivAiTe is a local proxy that sits between your app and the model provider. It finds names, emails, phone numbers, cards, IBANs, secrets and more, swaps them for stand-ins before anything leaves your machine, and puts the real values back in the reply. Most tools scan only the plain message text and miss the rest, which is the gap PrivAiTe closes. Detection runs on your machine and nothing phones home. By default it runs the full ONNX suite, so it also catches **secrets and passwords**, not just the easy regex entities. It exposes an OpenAI-compatible API you can point any existing client at, and the same engine runs three ways: as a standalone proxy, an Open WebUI filter, or a LiteLLM guardrail.
 
 ```
 You type: "Je m'appelle Marie Dupont, email marie@acme.com"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security policy
+
+## Supported versions
+
+Only the latest released version of `privaite` (on PyPI) receives security fixes.
+Please upgrade before reporting.
+
+## Reporting a vulnerability
+
+Do not open a public issue for security problems. Report privately through GitHub's
+private vulnerability reporting:
+
+https://github.com/crp4222/PrivAiTe/security/advisories/new
+
+Include a description, affected version, and steps to reproduce. This is a
+best-effort, single-maintainer project, so please allow time for a response.
+
+## Scope
+
+PrivAiTe performs reversible pseudonymization, not guaranteed anonymization, and
+detection is best-effort. Missed PII from an imperfect detection is a known
+limitation documented in the README threat model, not a vulnerability. Genuine
+security issues include, for example: the reversible map leaking to logs or disk,
+raw PII reaching a provider on a path that should have been scrubbed, or the
+fail-closed behavior being bypassed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ privaite = "privaite.cli:main"
 [project.urls]
 Homepage = "https://github.com/crp4222/PrivAiTe"
 Repository = "https://github.com/crp4222/PrivAiTe"
+Documentation = "https://github.com/crp4222/PrivAiTe#readme"
+Issues = "https://github.com/crp4222/PrivAiTe/issues"
 Changelog = "https://github.com/crp4222/PrivAiTe/blob/main/CHANGELOG.md"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Docs and metadata for discoverability, no functional change and no release.

- README: plain subtitle under the title, PyPI downloads badge, intro keyword dedupe, one early line naming the standalone/Open WebUI/LiteLLM modes
- AGENTS.md: canonical agent guide (renamed from CLAUDE.md)
- SECURITY.md: private vulnerability reporting policy
- pyproject: add Documentation and Issues project URLs
- dependabot: weekly grouped updates for pip and github-actions